### PR TITLE
Use test-unit gem explicitly

### DIFF
--- a/fluent-plugin-rewrite.gemspec
+++ b/fluent-plugin-rewrite.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency "rake"
+  gem.add_development_dependency "test-unit", "~> 3.1"
   gem.add_runtime_dependency     "fluentd"
 end
 


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatibile
layer.
Enjoy fluentd plugin development with Ruby 2.2!